### PR TITLE
Fix warning of missing key attribute when having multiple custom arrows.

### DIFF
--- a/package/src/components/Board.js
+++ b/package/src/components/Board.js
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { Fragment, useState, useRef, useEffect } from 'react';
 
 import { getRelativeCoords } from '../functions';
 import { Notation } from './Notation';
@@ -69,7 +69,7 @@ export function Board() {
           const to = getRelativeCoords(boardOrientation, boardWidth, arrow[1]);
 
           return (
-            <>
+            <Fragment key={i}>
               <defs>
                 <marker id="arrowhead" markerWidth="2" markerHeight="2.5" refX="1.25" refY="1.25" orient="auto">
                   <polygon points="0 0, 2 1.25, 0 2.5" style={{ fill: customArrowColor }} />
@@ -80,11 +80,10 @@ export function Board() {
                 y1={from.y}
                 x2={to.x}
                 y2={to.y}
-                key={i}
                 style={{ stroke: customArrowColor, strokeWidth: boardWidth / 36 }}
                 markerEnd="url(#arrowhead)"
               />
-            </>
+            </Fragment>
           );
         })}
       </svg>

--- a/package/src/components/Board.js
+++ b/package/src/components/Board.js
@@ -64,12 +64,12 @@ export function Board() {
         height={boardWidth}
         style={{ position: 'absolute', top: '0', left: '0', pointerEvents: 'none', zIndex: '10' }}
       >
-        {arrows.map((arrow, i) => {
+        {arrows.map(arrow => {
           const from = getRelativeCoords(boardOrientation, boardWidth, arrow[0]);
           const to = getRelativeCoords(boardOrientation, boardWidth, arrow[1]);
 
           return (
-            <Fragment key={i}>
+            <Fragment key={`${arrow[0]}-${arrow[1]}`}>
               <defs>
                 <marker id="arrowhead" markerWidth="2" markerHeight="2.5" refX="1.25" refY="1.25" orient="auto">
                   <polygon points="0 0, 2 1.25, 0 2.5" style={{ fill: customArrowColor }} />


### PR DESCRIPTION
Fixes the `Warning: Each child in a list should have a unique "key" prop.` warning when having multiple custom arrows.