### PR TITLE
Fix initial custom arrows not being drawn.

### DIFF
--- a/package/src/context/chessboard-context.js
+++ b/package/src/context/chessboard-context.js
@@ -93,11 +93,6 @@ export const ChessboardProvider = forwardRef(
       }
     }));
 
-    // handle external arrows change
-    useEffect(() => {
-      setArrows(customArrows);
-    }, [customArrows]);
-
     // handle custom pieces change
     useEffect(() => {
       setChessPieces({ ...defaultPieces, ...customPieces });
@@ -161,6 +156,11 @@ export const ChessboardProvider = forwardRef(
         clearTimeout(previousTimeout);
       };
     }, [position]);
+
+    // handle external arrows change
+    useEffect(() => {
+      setArrows(customArrows);
+    }, [customArrows]);
 
     // handle drop position change
     function handleSetPosition(sourceSq, targetSq, piece) {


### PR DESCRIPTION
In the example below, the initially provided custom arrow is not drawn. This PR fixes it.

```jsx
<Chessboard
  customArrows={[["e2", "e4"]]}
  boardWidth={300}
/>
```

