### PR TITLE
fix(capture-going-underneath): Bump z-index to cover the captured piece

### DIFF
--- a/package/dist/index.esm.js
+++ b/package/dist/index.esm.js
@@ -10230,7 +10230,8 @@ function Piece({
       if (sourceSq && targetSq) {
         setPieceStyle(oldPieceStyle => ({ ...oldPieceStyle,
           transform: `translate(${targetSq.x - sourceSq.x}px, ${targetSq.y - sourceSq.y}px)`,
-          transition: `transform ${animationDuration}ms`
+          transition: `transform ${animationDuration}ms`,
+          zIndex: 6
         }));
       }
     }

--- a/package/dist/index.js
+++ b/package/dist/index.js
@@ -10238,7 +10238,8 @@ function Piece({
       if (sourceSq && targetSq) {
         setPieceStyle(oldPieceStyle => ({ ...oldPieceStyle,
           transform: `translate(${targetSq.x - sourceSq.x}px, ${targetSq.y - sourceSq.y}px)`,
-          transition: `transform ${animationDuration}ms`
+          transition: `transform ${animationDuration}ms`,
+          zIndex: 6
         }));
       }
     }

--- a/package/src/components/Piece.js
+++ b/package/src/components/Piece.js
@@ -93,7 +93,8 @@ export function Piece({ piece, square, squares, isPremovedPiece = false }) {
         setPieceStyle((oldPieceStyle) => ({
           ...oldPieceStyle,
           transform: `translate(${targetSq.x - sourceSq.x}px, ${targetSq.y - sourceSq.y}px)`,
-          transition: `transform ${animationDuration}ms`
+          transition: `transform ${animationDuration}ms`,
+          zIndex: 6
         }));
       }
     }


### PR DESCRIPTION
Hi, here's another small PR!

I've noticed when doing animated captures (e.g. when using click to move, or the computer doing automatic moves), "sometimes" the capturing piece goes underneath the captured piece, which looks a bit off. This happens based on the DOM ordering, because they all have the same z-index of 5, so in particular when capturing to the right or down. In this PR I've fixed it by giving pieces in the process of transitioning a slightly higher z-index (6) to always cover the captured piece. It's still below dragged pieces (z-index 10).

Thanks!