### PR TITLE
fix(styled-example): Use DIVs instead of IMGs, fixes #20

### DIFF
--- a/example/src/boards/StyledBoard.js
+++ b/example/src/boards/StyledBoard.js
@@ -31,7 +31,14 @@ export default function StyledBoard({ boardWidth }) {
     const returnPieces = {};
     pieces.map((p) => {
       returnPieces[p] = ({ squareWidth }) => (
-        <img style={{ width: squareWidth, height: squareWidth }} src={`/media/${p}.png`} alt={p} />
+        <div
+          style={{
+            width: squareWidth,
+            height: squareWidth,
+            backgroundImage: `url(/media/${p}.png)`,
+            backgroundSize: '100%',
+          }}
+        />
       );
       return null;
     });


### PR DESCRIPTION
Fix for #20, as discussed by replacing the IMGs with DIVs. Tested in Safari @ macOS and the issue is gone.