### PR TITLE
fix(clearPremoves): pass clearLastPieceColour when calling clearPremoves

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm i react-chessboard
 ### Current
 
 - Accessible Functions
-  - `chessboardRef.current.clearPremoves();`
+  - `chessboardRef.current.clearPremoves();`, takes optional boolean parameter `clearLastPieceColour` to allow/disallow further premoves of the last moved piece color. `Default: true`
 - Board Orientation Choice
 - Custom Actions
   - getPositionObject

--- a/package/dist/index.esm.js
+++ b/package/dist/index.esm.js
@@ -9701,8 +9701,8 @@ const ChessboardProvider = /*#__PURE__*/forwardRef(({
   const [waitingForAnimation, setWaitingForAnimation] = useState(false); // open clearPremoves() to allow user to call on undo/reset/whenever
 
   useImperativeHandle(ref, () => ({
-    clearPremoves() {
-      clearPremoves();
+    clearPremoves(clearLastPieceColour = true) {
+      clearPremoves(clearLastPieceColour);
     }
 
   })); // handle custom pieces change

--- a/package/dist/index.js
+++ b/package/dist/index.js
@@ -9709,8 +9709,8 @@ const ChessboardProvider = /*#__PURE__*/React.forwardRef(({
   const [waitingForAnimation, setWaitingForAnimation] = React.useState(false); // open clearPremoves() to allow user to call on undo/reset/whenever
 
   React.useImperativeHandle(ref, () => ({
-    clearPremoves() {
-      clearPremoves();
+    clearPremoves(clearLastPieceColour = true) {
+      clearPremoves(clearLastPieceColour);
     }
 
   })); // handle custom pieces change

--- a/package/src/context/chessboard-context.js
+++ b/package/src/context/chessboard-context.js
@@ -91,8 +91,8 @@ export const ChessboardProvider = forwardRef(
 
     // open clearPremoves() to allow user to call on undo/reset/whenever
     useImperativeHandle(ref, () => ({
-      clearPremoves() {
-        clearPremoves();
+      clearPremoves(clearLastPieceColour = true) {
+        clearPremoves(clearLastPieceColour);
       }
     }));
 


### PR DESCRIPTION
I have passed the `clearLastPieceColour` argument to `clearPremoves` when called externally, so that code will be consistent for external use as well.