### PR TITLE
bugfix/click-to-move

### DIFF
--- a/example/src/boards/ClickToMove.js
+++ b/example/src/boards/ClickToMove.js
@@ -26,24 +26,27 @@ export default function ClickToMove({ boardWidth }) {
       square,
       verbose: true
     });
-    if (moves.length === 0) {
-      return;
-    }
 
     const newSquares = {};
-    moves.map((move) => {
-      newSquares[move.to] = {
-        background:
-          game.get(move.to) && game.get(move.to).color !== game.get(square).color
-            ? 'radial-gradient(circle, rgba(0,0,0,.1) 85%, transparent 85%)'
-            : 'radial-gradient(circle, rgba(0,0,0,.1) 25%, transparent 25%)',
-        borderRadius: '50%'
-      };
-      return move;
-    });
+
+    if(game.get(square) !== null) // If the square isn't empty
     newSquares[square] = {
       background: 'rgba(255, 255, 0, 0.4)'
     };
+
+    if (moves.length !== 0) {
+      moves.map((move) => {
+        newSquares[move.to] = {
+          background:
+            game.get(move.to) && game.get(move.to).color !== game.get(square).color
+              ? 'radial-gradient(circle, rgba(0,0,0,.1) 85%, transparent 85%)'
+              : 'radial-gradient(circle, rgba(0,0,0,.1) 25%, transparent 25%)',
+          borderRadius: '50%'
+        };
+        return move;
+      });
+    }
+
     setOptionSquares(newSquares);
   }
 


### PR DESCRIPTION
The bug was, when clicked on a piece, and afterwards an empty square, the possible options for the piece was still showing. But when you clicked on a possible square, nothing was happening.

I fixed it by removing the options that were being shown after clicking on an invalid square.

Also, before, when you clicked on a piece without any possible moves, it wasn't showing anything on the board. But now, even though the piece has no possible moves, it highlights the piece. I thought it would be more inituitive.

I also wanted to not show anything when clicked on an enemy piece but i thought that would be an overkill and out of subject of the example so i didn't.

Thanks <3