### PR TITLE
Bug fix: Click to Move story does not reset correctly if square click…

### DIFF
--- a/stories/Chessboard.stories.tsx
+++ b/stories/Chessboard.stories.tsx
@@ -146,7 +146,7 @@ export const ClickToMove = () => {
       verbose: true,
     });
     if (moves.length === 0) {
-      return;
+      return false;
     }
 
     const newSquares = {};
@@ -164,6 +164,7 @@ export const ClickToMove = () => {
       background: "rgba(255, 255, 0, 0.4)",
     };
     setOptionSquares(newSquares);
+    return true;
   }
 
   function makeRandomMove() {
@@ -182,8 +183,8 @@ export const ClickToMove = () => {
     setRightClickedSquares({});
 
     function resetFirstMove(square) {
-      setMoveFrom(square);
-      getMoveOptions(square);
+      const hasOptions = getMoveOptions(square);
+      if (hasOptions) setMoveFrom(square);
     }
 
     // from square


### PR DESCRIPTION
This PR fixes a bug in the "Click to Move" story - https://react-chessboard.com/?path=/story/example-chessboard--click-to-move

To reproduce:
1. Click a square with a piece
2. Click a square with no piece. You should see no changes in the options as well as the original piece selected
3. Try to move the original piece by clicking a valid square option displayed on the board. The piece highlighted won't move



https://user-images.githubusercontent.com/39115672/222612862-db54f394-4ad1-445a-91ea-e7a4a08e0361.mov



