### PR TITLE
Fix issues with ending arrow on same square as start

### DIFF
--- a/src/chessboard/context/chessboard-context.tsx
+++ b/src/chessboard/context/chessboard-context.tsx
@@ -289,7 +289,7 @@ export const ChessboardProvider = forwardRef(
       };
     }, [position]);
 
-    const { arrows, newArrow, clearArrows, drawNewArrow, onArrowDrawEnd, hasDrawnArrowOnDrag } =
+    const { arrows, newArrow, clearArrows, drawNewArrow, onArrowDrawEnd, isCurrentlyDrawingArrow } =
       useArrows(customArrows, areArrowsAllowed, onArrowsChange);
 
     // handle drop position change
@@ -408,7 +408,7 @@ export const ChessboardProvider = forwardRef(
 
     function onRightClickUp(square: Square) {
       if (currentRightClickDown
-        && !hasDrawnArrowOnDrag) {
+        && !isCurrentlyDrawingArrow) {
         // same square, don't draw an arrow, but do clear premoves and run onSquareRightClick
         if (currentRightClickDown === square) {
           setCurrentRightClickDown(undefined);

--- a/src/chessboard/context/chessboard-context.tsx
+++ b/src/chessboard/context/chessboard-context.tsx
@@ -289,7 +289,7 @@ export const ChessboardProvider = forwardRef(
       };
     }, [position]);
 
-    const { arrows, newArrow, clearArrows, drawNewArrow, onArrowDrawEnd } =
+    const { arrows, newArrow, clearArrows, drawNewArrow, onArrowDrawEnd, hasDrawnArrowOnDrag } =
       useArrows(customArrows, areArrowsAllowed, onArrowsChange);
 
     // handle drop position change
@@ -407,7 +407,8 @@ export const ChessboardProvider = forwardRef(
     }
 
     function onRightClickUp(square: Square) {
-      if (currentRightClickDown) {
+      if (currentRightClickDown
+        && !hasDrawnArrowOnDrag) {
         // same square, don't draw an arrow, but do clear premoves and run onSquareRightClick
         if (currentRightClickDown === square) {
           setCurrentRightClickDown(undefined);

--- a/src/chessboard/hooks/useArrows.ts
+++ b/src/chessboard/hooks/useArrows.ts
@@ -20,7 +20,7 @@ export const useArrows = (
   // arrow which we draw while user dragging mouse
   const [newArrow, setNewArrow] = useState<Arrow>();
 
-  const [isCurrentlyDrawingArrow, setIscurrentlyDrawingArrow] = useState(false);
+  const [isCurrentlyDrawingArrow, setIsCurrentlyDrawingArrow] = useState(false);
 
   // handle external arrows change
   useEffect(() => {
@@ -63,13 +63,13 @@ export const useArrows = (
       setNewArrow(undefined)
     } else {
       // if not already, set isCurrentlyDrawingArrow to true
-      !isCurrentlyDrawingArrow && setIscurrentlyDrawingArrow(true)
+      !isCurrentlyDrawingArrow && setIsCurrentlyDrawingArrow(true)
       setNewArrow([fromSquare, toSquare]);
     }
   };
 
   const onArrowDrawEnd = (fromSquare: Square, toSquare: Square) => {
-    setIscurrentlyDrawingArrow(false)
+    setIsCurrentlyDrawingArrow(false)
     if (fromSquare === toSquare) return;
     // remove it if we already have same arrow in arrows set
     const newArrow = `${fromSquare},${toSquare}`;

--- a/src/chessboard/hooks/useArrows.ts
+++ b/src/chessboard/hooks/useArrows.ts
@@ -20,7 +20,7 @@ export const useArrows = (
   // arrow which we draw while user dragging mouse
   const [newArrow, setNewArrow] = useState<Arrow>();
 
-  const [hasDrawnArrowOnDrag, setHasDrawnArrowOnDrag] = useState(false);
+  const [isCurrentlyDrawingArrow, setIscurrentlyDrawingArrow] = useState(false);
 
   // handle external arrows change
   useEffect(() => {
@@ -58,16 +58,18 @@ export const useArrows = (
 
   const drawNewArrow = (fromSquare: Square, toSquare: Square) => {
     if (!areArrowsAllowed) return;
+    // if fromSquare is same as toSquare, remove newArrow
     if (fromSquare === toSquare) {
       setNewArrow(undefined)
     } else {
-      setHasDrawnArrowOnDrag(true)
+      // if not already, set isCurrentlyDrawingArrow to true
+      !isCurrentlyDrawingArrow && setIscurrentlyDrawingArrow(true)
       setNewArrow([fromSquare, toSquare]);
     }
   };
 
   const onArrowDrawEnd = (fromSquare: Square, toSquare: Square) => {
-    setHasDrawnArrowOnDrag(false)
+    setIscurrentlyDrawingArrow(false)
     if (fromSquare === toSquare) return;
     // remove it if we already have same arrow in arrows set
     const newArrow = `${fromSquare},${toSquare}`;
@@ -86,7 +88,7 @@ export const useArrows = (
   return {
     arrows: toArray(arrows),
     newArrow,
-    hasDrawnArrowOnDrag,
+    isCurrentlyDrawingArrow,
     clearArrows,
     removeArrow,
     drawNewArrow,

--- a/src/chessboard/hooks/useArrows.ts
+++ b/src/chessboard/hooks/useArrows.ts
@@ -20,6 +20,8 @@ export const useArrows = (
   // arrow which we draw while user dragging mouse
   const [newArrow, setNewArrow] = useState<Arrow>();
 
+  const [hasDrawnArrowOnDrag, setHasDrawnArrowOnDrag] = useState(false);
+
   // handle external arrows change
   useEffect(() => {
     if (customArrows && (customArrows.length !== 0 || arrows.size > 0)) {
@@ -55,12 +57,17 @@ export const useArrows = (
   };
 
   const drawNewArrow = (fromSquare: Square, toSquare: Square) => {
-    if (!areArrowsAllowed || fromSquare === toSquare) return;
-
-    setNewArrow([fromSquare, toSquare]);
+    if (!areArrowsAllowed) return;
+    if (fromSquare === toSquare) {
+      setNewArrow(undefined)
+    } else {
+      setHasDrawnArrowOnDrag(true)
+      setNewArrow([fromSquare, toSquare]);
+    }
   };
 
   const onArrowDrawEnd = (fromSquare: Square, toSquare: Square) => {
+    setHasDrawnArrowOnDrag(false)
     if (fromSquare === toSquare) return;
     // remove it if we already have same arrow in arrows set
     const newArrow = `${fromSquare},${toSquare}`;
@@ -79,6 +86,7 @@ export const useArrows = (
   return {
     arrows: toArray(arrows),
     newArrow,
+    hasDrawnArrowOnDrag,
     clearArrows,
     removeArrow,
     drawNewArrow,


### PR DESCRIPTION
The issue:
Different behaviors relating to starting the drawing of arrow, and ending on the original square:

- If a user starts drawing an arrow, and drags back to the original square without letting go, the arrow stays on the last valid square, instead of cancelling.
- If the user does let go on the original square, the incorrect arrow is persisted. It is only removed when the user begins creating another arrow.
- Additionally, if the user lets go on the original square, the onRightClickUp event is fired. I don't believe this is intuitive if the user started creating an arrow; the user very likely only wants to cancel the original arrow.


https://github.com/Clariity/react-chessboard/assets/20730722/9e45a356-2d36-4731-a082-8e86dac2a9cb


The PR:
- Removes newArrow (newArrow = undefined) if user drags over the same square (toSqare) as the starting square (fromSqare)
- Creates isCurrentlyDrawingArrow prop. This is set to true when the user begins drawing an arrow, and false onArrowDrawEnd. This is different from checking only if newArrow exists, since newArrow can now be removed without right click being lifted.
- Prevents onRightClickUp function from triggering if isCurrentlyDrawingArrow is true. onRightClickUp is maintained if the user right clicks without dragging.


https://github.com/Clariity/react-chessboard/assets/20730722/4448ef00-48eb-4c47-b02c-247839ba73fc