### PR TITLE
fix: promotion dialog modal background

### DIFF
--- a/src/chessboard/components/PromotionDialog.tsx
+++ b/src/chessboard/components/PromotionDialog.tsx
@@ -37,7 +37,7 @@ export function PromotionDialog() {
       width: "100%",
       height: `${boardWidth / 4}px`,
       top: 0,
-      backgroundColor: "white",
+      backgroundColor: "transparent",
       left: 0,
     },
   };

--- a/stories/Chessboard.stories.tsx
+++ b/stories/Chessboard.stories.tsx
@@ -438,7 +438,6 @@ export const ClickToMove = () => {
           ...rightClickedSquares,
         }}
         promotionToSquare={moveTo}
-        promotionDialogVariant={'modal'}
         showPromotionDialog={showPromotionDialog}
       />
       <button

--- a/stories/Chessboard.stories.tsx
+++ b/stories/Chessboard.stories.tsx
@@ -438,6 +438,7 @@ export const ClickToMove = () => {
           ...rightClickedSquares,
         }}
         promotionToSquare={moveTo}
+        promotionDialogVariant={'modal'}
         showPromotionDialog={showPromotionDialog}
       />
       <button


### PR DESCRIPTION
Modal variant of the promotion dialog looks like it was accidentally left with a white background. Especially since all other dialog backgrounds are transparent. Extremely small change but since I am using this modal version it is something I thought worth making a PR for instead of my css hacks to fix it. 

From: 
![Screenshot from 2023-07-08 18-17-16](https://github.com/Clariity/react-chessboard/assets/12035243/1b494e4b-6059-4c70-9048-cf60d8bddf1d)

To: 
![Screenshot from 2023-07-08 18-17-58](https://github.com/Clariity/react-chessboard/assets/12035243/010592c0-8b3a-452e-9e57-87678d125058)

