### PR TITLE
fix: board notation remove user select

### DIFF
--- a/src/chessboard/components/Notation.tsx
+++ b/src/chessboard/components/Notation.tsx
@@ -60,6 +60,7 @@ export function Notation({ row, col }: NotationProps) {
     return (
       <div
         style={{
+          pointerEvents: "none",
           zIndex: 3,
           position: "absolute",
           ...{ color: col % 2 !== 0 ? blackColor : whiteColor },
@@ -75,6 +76,7 @@ export function Notation({ row, col }: NotationProps) {
     return (
       <div
         style={{
+          pointerEvents: "none",
           zIndex: 3,
           position: "absolute",
           ...(boardOrientation === "black"

--- a/src/chessboard/components/Notation.tsx
+++ b/src/chessboard/components/Notation.tsx
@@ -60,7 +60,7 @@ export function Notation({ row, col }: NotationProps) {
     return (
       <div
         style={{
-          pointerEvents: "none",
+          userSelect: "none",
           zIndex: 3,
           position: "absolute",
           ...{ color: col % 2 !== 0 ? blackColor : whiteColor },
@@ -76,7 +76,7 @@ export function Notation({ row, col }: NotationProps) {
     return (
       <div
         style={{
-          pointerEvents: "none",
+          userSelect: "none",
           zIndex: 3,
           position: "absolute",
           ...(boardOrientation === "black"


### PR DESCRIPTION
Fixed a small issue where users would try to drag/drop but would select the board notation