### PR TITLE
fix maximum update depth exceeded issue

### DIFF
--- a/src/chessboard/index.tsx
+++ b/src/chessboard/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useRef, useState } from "react";
+import { forwardRef, useEffect, useMemo, useRef, useState } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { TouchBackend } from "react-dnd-touch-backend";
@@ -41,7 +41,10 @@ export const Chessboard = forwardRef<ClearPremoves, ChessboardProps>(
       top: 0,
     });
 
-    const metrics = boardRef.current?.getBoundingClientRect();
+    const metrics = useMemo(
+      () => boardRef.current?.getBoundingClientRect(),
+      [boardRef.current]
+    );
 
     useEffect(() => {
       setBoardContainerPos({


### PR DESCRIPTION
I saw this issue on stackoverflow [https://stackoverflow.com/questions/77380011/simple-component-in-react-chessboard-is-causing-constant-maximum-update-depth-e].

The issue is,

-  when the `Chessboard` component is imported and mounted on the DOM, there is a "maximum update depth exceeded" error.

since `metrics` variable which is an object is given as a dependency to useEffect which in turn sets a state variable, there was infinite re-render.

Attaching a screenshot for your reference.
![chessboard-rerender-issue](https://github.com/Clariity/react-chessboard/assets/73982249/9caee479-10db-4394-bb09-43e86114120a)
