### PR TITLE
Added tablet support for onDragOverSquare function

### DIFF
--- a/src/chessboard/components/Square.tsx
+++ b/src/chessboard/components/Square.tsx
@@ -39,6 +39,7 @@ export function Square({
     handleSetPosition,
     isWaitingForAnimation,
     lastPieceColour,
+    lastSquareDraggedOver,
     onArrowDrawEnd,
     onDragOverSquare,
     onMouseOutSquare,
@@ -48,11 +49,10 @@ export function Square({
     onRightClickDown,
     onRightClickUp,
     onSquareClick,
+    setLastSquareDraggedOver,
     setPromoteFromSquare,
     setPromoteToSquare,
     setShowPromoteDialog,
-    lastSquareDraggedOver,
-    setLastSquareDraggedOver,
   } = useChessboard();
 
   const [{ isOver }, drop] = useDrop(

--- a/src/chessboard/components/Square.tsx
+++ b/src/chessboard/components/Square.tsx
@@ -113,6 +113,20 @@ export function Square({
       style={defaultSquareStyle}
       data-square-color={squareColor}
       data-square={square}
+      onTouchMove={(e) => {
+        // Handle touch events on tablet and mobile not covered by onMouseOver
+        const touchLocation = e.touches[0];
+        const touchElement = document.elementsFromPoint(
+          touchLocation.clientX,
+          touchLocation.clientY
+        );
+        const square = touchElement
+          ?.find((el) => el.getAttribute("data-square"))
+          ?.getAttribute("data-square") as Sq;
+        if (square) {
+          onMouseOverSquare(square);
+        }
+      }}
       onMouseOver={(e) => {
         // noop if moving from child of square into square.
 

--- a/src/chessboard/components/Square.tsx
+++ b/src/chessboard/components/Square.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useRef, useState } from "react";
+import { ReactNode, useEffect, useRef } from "react";
 import { useDrop } from "react-dnd";
 
 import { useChessboard } from "../context/chessboard-context";
@@ -51,6 +51,8 @@ export function Square({
     setPromoteFromSquare,
     setPromoteToSquare,
     setShowPromoteDialog,
+    lastSquareDraggedOver,
+    setLastSquareDraggedOver,
   } = useChessboard();
 
   const [{ isOver }, drop] = useDrop(
@@ -69,8 +71,6 @@ export function Square({
       lastPieceColour,
     ]
   );
-  const [lastSquareDraggedOver, setLastSquareDraggedOver] =
-    useState<Sq | null>(null);
 
   function handleDrop(item: { piece: Piece; square: Sq; id: number }) {
     if (onPromotionCheck(item.square, square, item.piece)) {
@@ -122,12 +122,12 @@ export function Square({
           touchLocation.clientX,
           touchLocation.clientY
         );
-        const square = touchElement
+        const draggedOverSquare = touchElement
           ?.find((el) => el.getAttribute("data-square"))
           ?.getAttribute("data-square") as Sq;
-        if (square && square !== lastSquareDraggedOver) {
-          setLastSquareDraggedOver(square);
-          onDragOverSquare(square);
+        if (draggedOverSquare && draggedOverSquare !== lastSquareDraggedOver) {
+          setLastSquareDraggedOver(draggedOverSquare);
+          onDragOverSquare(draggedOverSquare);
         }
       }}
       onMouseOver={(e) => {

--- a/src/chessboard/components/Square.tsx
+++ b/src/chessboard/components/Square.tsx
@@ -116,7 +116,7 @@ export function Square({
       data-square-color={squareColor}
       data-square={square}
       onTouchMove={(e) => {
-        // Handle touch events on tablet and mobile not covered by onMouseOver
+        // Handle touch events on tablet and mobile not covered by onMouseOver/onDragEnter
         const touchLocation = e.touches[0];
         const touchElement = document.elementsFromPoint(
           touchLocation.clientX,

--- a/src/chessboard/components/Square.tsx
+++ b/src/chessboard/components/Square.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useRef } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 import { useDrop } from "react-dnd";
 
 import { useChessboard } from "../context/chessboard-context";
@@ -69,6 +69,8 @@ export function Square({
       lastPieceColour,
     ]
   );
+  const [lastSquareDraggedOver, setLastSquareDraggedOver] =
+    useState<Sq | null>(null);
 
   function handleDrop(item: { piece: Piece; square: Sq; id: number }) {
     if (onPromotionCheck(item.square, square, item.piece)) {
@@ -123,8 +125,9 @@ export function Square({
         const square = touchElement
           ?.find((el) => el.getAttribute("data-square"))
           ?.getAttribute("data-square") as Sq;
-        if (square) {
-          onMouseOverSquare(square);
+        if (square && square !== lastSquareDraggedOver) {
+          setLastSquareDraggedOver(square);
+          onDragOverSquare(square);
         }
       }}
       onMouseOver={(e) => {

--- a/src/chessboard/context/chessboard-context.tsx
+++ b/src/chessboard/context/chessboard-context.tsx
@@ -102,6 +102,8 @@ interface ChessboardProviderContext {
   setPromoteToSquare: React.Dispatch<React.SetStateAction<Square | null>>;
   setShowPromoteDialog: React.Dispatch<React.SetStateAction<boolean>>;
   showPromoteDialog: boolean;
+  lastSquareDraggedOver: Square | null;
+  setLastSquareDraggedOver: React.Dispatch<React.SetStateAction<Square | null>>;
 }
 
 export const ChessboardContext = createContext({} as ChessboardProviderContext);
@@ -220,6 +222,10 @@ export const ChessboardProvider = forwardRef(
 
     // if currently waiting for an animation to finish
     const [isWaitingForAnimation, setIsWaitingForAnimation] = useState(false);
+
+    // last square dragged over for checking in touch events
+    const [lastSquareDraggedOver, setLastSquareDraggedOver] =
+      useState<Square | null>(null);
 
     // open clearPremoves() to allow user to call on undo/reset/whenever
     useImperativeHandle(ref, () => ({
@@ -505,6 +511,8 @@ export const ChessboardProvider = forwardRef(
       showPromoteDialog,
       autoPromoteToQueen,
       currentRightClickDown,
+      lastSquareDraggedOver,
+      setLastSquareDraggedOver,
     };
 
     return (

--- a/src/chessboard/context/chessboard-context.tsx
+++ b/src/chessboard/context/chessboard-context.tsx
@@ -90,6 +90,7 @@ interface ChessboardProviderContext {
   ) => void;
   isWaitingForAnimation: boolean;
   lastPieceColour: string | undefined;
+  lastSquareDraggedOver: Square | null;
   newArrow?: Arrow;
   onArrowDrawEnd: (from: Square, to: Square) => void;
   onRightClickDown: (square: Square) => void;
@@ -98,12 +99,11 @@ interface ChessboardProviderContext {
   premoves: Premove[];
   promoteFromSquare: Square | null;
   promoteToSquare: Square | null;
+  setLastSquareDraggedOver: React.Dispatch<React.SetStateAction<Square | null>>;
   setPromoteFromSquare: React.Dispatch<React.SetStateAction<Square | null>>;
   setPromoteToSquare: React.Dispatch<React.SetStateAction<Square | null>>;
   setShowPromoteDialog: React.Dispatch<React.SetStateAction<boolean>>;
   showPromoteDialog: boolean;
-  lastSquareDraggedOver: Square | null;
-  setLastSquareDraggedOver: React.Dispatch<React.SetStateAction<Square | null>>;
 }
 
 export const ChessboardContext = createContext({} as ChessboardProviderContext);


### PR DESCRIPTION
On tablet, the onDragOverSquare function wasn't being called.
I added in an onTouchMove event on the square Div which now calls the onDragOverSquare if the square is different,

This maintains current behaviour of it only being called onEnter.