### PR TITLE
fix: small width board's pieces svg

### DIFF
--- a/src/chessboard/components/Piece.tsx
+++ b/src/chessboard/components/Piece.tsx
@@ -160,6 +160,7 @@ export function Piece({
           viewBox={"1 1 43 43"}
           width={boardWidth / 8}
           height={boardWidth / 8}
+          style={{ display: "block" }}
         >
           <g>{chessPieces[piece] as ReactNode}</g>
         </svg>


### PR DESCRIPTION
fixes https://github.com/Clariity/react-chessboard/issues/136