### PR TITLE
Fix drag boundary not updating when board is moved on screen

### DIFF
--- a/src/chessboard/components/CustomDragLayer.tsx
+++ b/src/chessboard/components/CustomDragLayer.tsx
@@ -1,14 +1,14 @@
-import { ReactNode, useCallback } from "react";
+import { ReactNode, RefObject, useCallback, useEffect, useState } from "react";
 import { useDragLayer, XYCoord } from "react-dnd";
 
 import { useChessboard } from "../context/chessboard-context";
 import { CustomPieceFn, Piece, Square } from "../types";
 
 export type CustomDragLayerProps = {
-  boardContainer: { left: number; top: number };
+  boardRef: RefObject<HTMLObjectElement>;
 };
 
-export function CustomDragLayer({ boardContainer }: CustomDragLayerProps) {
+export function CustomDragLayer({ boardRef }: CustomDragLayerProps) {
   const { boardWidth, chessPieces, id, snapToCursor, allowDragOutsideBoard } =
     useChessboard();
 
@@ -30,6 +30,12 @@ export function CustomDragLayer({ boardContainer }: CustomDragLayerProps) {
     sourceClientOffset: XYCoord | null;
     isDragging: boolean;
   } = collectedProps;
+
+  const [boardContainer, setBoardContainer] = useState({ left: 0, top: 0 })
+  useEffect(() => {
+    const rect = boardRef.current?.getBoundingClientRect()
+    setBoardContainer({ left: rect?.left || 0, top: rect?.top || 0 })
+  }, [boardRef.current, isDragging])
 
   const getItemStyle = useCallback(
     (clientOffset: XYCoord | null, sourceClientOffset: XYCoord | null) => {

--- a/src/chessboard/index.tsx
+++ b/src/chessboard/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useMemo, useRef, useState } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { TouchBackend } from "react-dnd-touch-backend";
@@ -32,26 +32,7 @@ export const Chessboard = forwardRef<ClearPremoves, ChessboardProps>(
     const [backendSet, setBackendSet] = useState(false);
     const [isMobile, setIsMobile] = useState(false);
     const [boardWidth, setBoardWidth] = useState(props.boardWidth);
-
     const boardRef = useRef<HTMLObjectElement>(null);
-    const boardContainerRef = useRef<HTMLDivElement>(null);
-
-    const [boardContainerPos, setBoardContainerPos] = useState({
-      left: 0,
-      top: 0,
-    });
-
-    const metrics = useMemo(
-      () => boardRef.current?.getBoundingClientRect(),
-      [boardRef.current]
-    );
-
-    useEffect(() => {
-      setBoardContainerPos({
-        left: metrics?.left ? metrics?.left : 0,
-        top: metrics?.top ? metrics?.top : 0,
-      });
-    }, [metrics]);
 
     useEffect(() => {
       setIsMobile("ontouchstart" in window);
@@ -78,7 +59,6 @@ export const Chessboard = forwardRef<ClearPremoves, ChessboardProps>(
     return backendSet && clientWindow ? (
       <ErrorBoundary>
         <div
-          ref={boardContainerRef}
           style={{
             display: "flex",
             flexDirection: "column",
@@ -97,7 +77,7 @@ export const Chessboard = forwardRef<ClearPremoves, ChessboardProps>(
                 {...otherProps}
                 ref={ref}
               >
-                <CustomDragLayer boardContainer={boardContainerPos} />
+                <CustomDragLayer boardRef={boardRef} />
                 <Board />
               </ChessboardProvider>
             )}


### PR DESCRIPTION
When `allowDragOutsideBoard` is false, pieces cannot be dragged outside of a bounding rectangle defined over the board's position on the screen. However, after the board has been rendered, this bounding rectangle is not updated when the screen is scrolled, the board is resized, or any other change in the DOM causes it's position on the screen to change.

This change simplifies the manner in which the board's bounds are calculated and stored. Instead of trying to calculate and memoize the position of the board on the screen in advance, the board's bounds are calculated only when the dragging state changes.


### Example of Incorrect Behaviour
This example from the Storybook shows how the bounding rectangle restricting where a piece may be dragged is not updated when the element moves on the screen. Here I have moved the board by manipulating other elements in the DOM, indicating that resize and scroll are not the only types of events that could trigger this behaviour.

https://github.com/user-attachments/assets/45fcf09d-ef9f-4aee-925f-697812f27f4a

### Example of Improved Behaviour
This example from the Storybook after this change is applied shows that the bounding rectangle restricting where a piece may be dragged continues to match the visible location of the board when the board is moved from its initial position.

https://github.com/user-attachments/assets/2935ac30-e18e-4ffb-815b-b9472253eb66

