### PR TITLE
fix: promotion choice logical error in basic example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,11 @@ export default function PlayRandomMoveEngine() {
     return true;
   }
 
-  return <Chessboard position={game.fen()} onPieceDrop={onDrop} />;
+  return <Chessboard
+    position={game.fen()}
+    onPieceDrop={onDrop}
+    autoPromoteToQueen={true} // always promote to a queen for example simplicity
+  />;
 }
 ```
 


### PR DESCRIPTION
promotion logic on the board and in the move validation library should be the same: always promote to a queen