### PR TITLE
Import chess as a constructor instead of module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ export default function App() {
 
 ```jsx
 import { useState } from "react";
-import Chess from "chess.js";
+import { Chess } from "chess.js";
 import { Chessboard } from "react-chessboard";
 
 export default function PlayRandomMoveEngine() {


### PR DESCRIPTION
The readme provides an incorrect way of importing the chess library. 