### PR TITLE
fix: internal arrows disappearing on drag start

### DIFF
--- a/src/ChessboardProvider.tsx
+++ b/src/ChessboardProvider.tsx
@@ -535,6 +535,7 @@ export function ChessboardProvider({
             sourceSquare: draggingPiece.position,
             targetSquare: dropSquare,
           });
+          clearArrows();
         }
         setDraggingPiece(null);
       }

--- a/src/Square.tsx
+++ b/src/Square.tsx
@@ -89,14 +89,14 @@ export const Square = memo(function Square({
         });
       }}
       onMouseDown={(e) => {
-        if (e.button === 0) {
-          clearArrows();
-        }
         if (e.button === 2 && allowDrawingArrows) {
           setNewArrowStartSquare(squareId);
         }
       }}
       onMouseUp={(e) => {
+        if (e.button === 0) {
+          clearArrows();
+        }
         if (e.button === 2) {
           if (newArrowStartSquare) {
             drawArrow(squareId, {


### PR DESCRIPTION
A simple fix making sure dragging a piece (and putting it back on its original square) does not clear internal arrows. Arrows instead clear on a successful piece drop.