### PR TITLE
refactor: when set to 0, dragActivationDistance begins drag as soon a…

### DIFF
--- a/src/ChessboardProvider.tsx
+++ b/src/ChessboardProvider.tsx
@@ -574,9 +574,9 @@ export function ChessboardProvider({
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
-      activationConstraint: {
+      activationConstraint: dragActivationDistance > 0 ? {
         distance: dragActivationDistance,
-      },
+      } : undefined,
     }),
     useSensor(KeyboardSensor),
     useSensor(TouchSensor),


### PR DESCRIPTION
…s the user holds down click

## Description

Drag activation distance when set at 0 wouldn't activate until the user moves the mouse. Now it activates drag as soon as they click. I believe this is better behavior.

## Type of change

Please delete options that are not relevant.

- [ ] Code refactoring

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
When setting drag activation to 0 in the storybook, you can see the drag now begins immediately.

## Checklist:

- [  ] My code follows the style guidelines of this project
- [  ] I have performed a self-review of my own code
- [  ] I have commented my code, particularly in hard-to-understand areas
- [  ] I have made corresponding changes to the documentation
- [  ] My changes generate no new warnings
- [  ] I have added tests that prove my fix is effective or that my feature works
- [  ] New and existing unit tests pass locally with my changes
- [  ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if appropriate):

## Additional context

Add any other context about the pull request here.
