### PR TITLE
refactor: use viewbox for arrows svg

### DIFF
--- a/src/Arrows.tsx
+++ b/src/Arrows.tsx
@@ -3,12 +3,7 @@ import { Fragment } from 'react';
 import { useChessboardContext } from './ChessboardProvider';
 import { getRelativeCoords } from './utils';
 
-type Props = {
-  boardWidth: number | undefined;
-  boardHeight: number | undefined;
-};
-
-export function Arrows({ boardWidth, boardHeight }: Props) {
+export function Arrows() {
   const {
     id,
     arrows,
@@ -21,9 +16,8 @@ export function Arrows({ boardWidth, boardHeight }: Props) {
     newArrowOverSquare,
   } = useChessboardContext();
 
-  if (!boardWidth) {
-    return null;
-  }
+  const viewBoxWidth = 2048;
+  const viewBoxHeight = viewBoxWidth * (chessboardRows / chessboardColumns);
 
   const currentlyDrawingArrow =
     newArrowStartSquare &&
@@ -42,11 +36,12 @@ export function Arrows({ boardWidth, boardHeight }: Props) {
 
   return (
     <svg
-      width={boardWidth}
-      height={boardHeight}
+      viewBox={`0 0 ${viewBoxWidth} ${viewBoxHeight}`}
       style={{
         position: 'absolute',
         top: '0',
+        right: '0',
+        bottom: '0',
         left: '0',
         pointerEvents: 'none',
         zIndex: '20', // place above pieces
@@ -55,21 +50,21 @@ export function Arrows({ boardWidth, boardHeight }: Props) {
       {arrowsToDraw.map((arrow, i) => {
         const from = getRelativeCoords(
           boardOrientation,
-          boardWidth,
+          viewBoxWidth,
           chessboardColumns,
           chessboardRows,
           arrow.startSquare,
         );
         const to = getRelativeCoords(
           boardOrientation,
-          boardWidth,
+          viewBoxWidth,
           chessboardColumns,
           chessboardRows,
           arrow.endSquare,
         );
 
         // we want to shorten the arrow length so the tip of the arrow is more central to the target square instead of running over the center
-        const squareWidth = boardWidth / chessboardColumns;
+        const squareWidth = viewBoxWidth / chessboardColumns;
         let ARROW_LENGTH_REDUCER =
           squareWidth / arrowOptions.arrowLengthReducerDenominator;
 

--- a/src/Board.tsx
+++ b/src/Board.tsx
@@ -1,6 +1,5 @@
 import { DragOverlay } from '@dnd-kit/core';
 import { snapCenterToCursor } from '@dnd-kit/modifiers';
-import { useEffect, useRef, useState } from 'react';
 
 import { Arrows } from './Arrows';
 import { Draggable } from './Draggable';
@@ -21,32 +20,11 @@ export function Board() {
     draggingPiece,
     id,
   } = useChessboardContext();
-  const boardRef = useRef<HTMLDivElement>(null);
-  const [boardWidth, setBoardWidth] = useState(boardRef.current?.clientWidth);
-  const [boardHeight, setBoardHeight] = useState(
-    boardRef.current?.clientHeight,
-  );
-
-  // if the board dimensions change, update the board width and height
-  useEffect(() => {
-    if (boardRef.current) {
-      const resizeObserver = new ResizeObserver(() => {
-        setBoardWidth(boardRef.current?.clientWidth as number);
-        setBoardHeight(boardRef.current?.clientHeight as number);
-      });
-      resizeObserver.observe(boardRef.current);
-
-      return () => {
-        resizeObserver.disconnect();
-      };
-    }
-  }, [boardRef.current]);
 
   return (
     <>
       <div
         id={`${id}-board`}
-        ref={boardRef}
         style={{ ...defaultBoardStyle(chessboardColumns), ...boardStyle }}
       >
         {board.map((row) =>
@@ -73,7 +51,7 @@ export function Board() {
           }),
         )}
 
-        <Arrows boardWidth={boardWidth} boardHeight={boardHeight} />
+        <Arrows />
       </div>
 
       <DragOverlay


### PR DESCRIPTION
## Description

Hi, thanks for this library, so many killer features and very configurable! I've been using it in a project where I render multiple boards in a grid with initial arrows drawn on them. Also my board dimensions change when a sidebar is animated in/out. I've noticed that,

- the initial arrow drawing had a slight delay,
- the arrow position updates were not instant when board size changes,
- my animations were not smooth due many re-renders of all the boards.

This refactor removes the resize observer from the board and uses `viewBox` in the arrow container svg, so the repositioning is left to browser, without re-renders. It should also be more SSR friendly, since the arrows can be generated on the server.

I haven't created an issue first because I didn't think this is a big change. Please let me know if I should do that.

## Type of change

- [x] Performance improvement
- [x] Code refactoring

## How Has This Been Tested?

- [x] In stories, the arrows are drawn the same as before
- [x] In stories, the arrows update their position correctly when the board is resized (by resizing the browser window)
- [x] In stories, the arrows are drawn and positions are updated correctly for irregular boards (e.g. 8x16, 16x8) as before

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

