### PR TITLE
chore: add jsx-runtime as external dependency

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,5 +25,5 @@ export default {
       tsconfig: 'tsconfig.build.json',
     }),
   ],
-  external: ['react', 'react-dom'],
+  external: ['react', 'react-dom', 'react/jsx-runtime'],
 };


### PR DESCRIPTION
## Description

Prevents `react/jsx-runtime` from bundling. Shaves off a little from bundle size.

## Type of change

Bundle size improvement

## How Has This Been Tested?

- [x] Verify storybook loads without errors

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
