### PR TITLE
fix: prevent dnd hydration errors

### DIFF
--- a/src/ChessboardProvider.tsx
+++ b/src/ChessboardProvider.tsx
@@ -16,7 +16,6 @@ import {
   use,
   useCallback,
   useEffect,
-  useId,
   useMemo,
   useRef,
   useState,
@@ -302,7 +301,7 @@ export function ChessboardProvider({
   const animationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // unique id for dnd context, we need this to prevent hydration issues
-  const dndId = useId();
+  const dndId = `dnd-${id}`;
 
   // if the position changes, we need to recreate the pieces array
   useEffect(() => {


### PR DESCRIPTION
## Description

When rendering more than one board with SSR, hydration sometimes fails like this:

<img width="947" height="431" alt="image" src="https://github.com/user-attachments/assets/2d2c15f3-f82a-46d3-99fc-ec6f578ae357" />

This is because dnd-kit is generating ids on the fly and sometimes generated ids don't match between server and client. This has been [resolved ](https://github.com/clauderic/dnd-kit/pull/288) on dnd-kit side but it's an opt-in change. This PR uses `id` prop on `DndContext` to guarantee server and client side ids always match

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Not possible to verify the fix itself on storybook since it doesn't do SSR

- [x] Verified storybook dnd examples work as before

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
