### PR TITLE
docs: fix reset button in piece promotion advanced example

### DIFF
--- a/docs/stories/advanced-examples/PiecePromotion.stories.tsx
+++ b/docs/stories/advanced-examples/PiecePromotion.stories.tsx
@@ -133,7 +133,7 @@ export const PiecePromotion: Story = {
         <button
           onClick={() => {
             chessGameRef.current = new Chess('8/P7/7K/8/8/8/8/k7 w - - 0 1');
-            setChessPosition(chessGame.fen());
+            setChessPosition(chessGameRef.current.fen());
             setPromotionMove(null);
           }}
         >


### PR DESCRIPTION
In the storybook, in "Advanced examples" > "Promotion piece selection" section, the "Reset Position" button did not work, I fixed it.