### PR TITLE
fix: promoting moves are animated

### DIFF
--- a/src/ChessboardProvider.tsx
+++ b/src/ChessboardProvider.tsx
@@ -391,6 +391,7 @@ export function ChessboardProvider({
       return;
     }
 
+    // this extra position check will only run if the position HAS changed, but we have been unable to identify the pieces that have moved, reducing the impact of the performance overhead
     if (Object.keys(positionUpdates).length === 0) {
       const promotionUpdates = getPromotionUpdates(
         currentWaitingForAnimationPosition ?? currentPosition,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -349,6 +349,8 @@ function pawnPromotesAtSquares(
     chessColumnToColumnIndex(pawnSquare[0], noOfColumns, 'black') -
       chessColumnToColumnIndex(promotionSquare[0], noOfColumns, 'black'),
   );
+
+  // ensure piece has moved at most 1 column away and is the same colour
   if (columnDifference > 1 || oldPiece[0] !== newPiece[0]) {
     return false;
   }


### PR DESCRIPTION
## Description

I added `utils.getPromotionUpdates` and `utils.pawnPromotesAtSquares` to identify promoting moves.

In the animation useEffect I added a condition where the promotion is animated only if `positionUpdates` doesn't have any pieces to animate and `promotionUpdates` has one piece to animate. I added these constraints to simplify the problem, because the main benefit of the fix is to animate when only the promotion move is being played or undone. In other cases it can be hard to verify if the promotion actually happened or how you should handle conflicts with `positionUpdates`.

Fixes #220 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Verified the animation happens when the engine promotes in Storybook > Options API > animationDurationInMs

I didn't write any unit tests for my logic because I didn't see a test suite to add them to. Let me know if I'm misunderstanding storybook!

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if appropriate):

## Additional context

Add any other context about the pull request here.
