### PR TITLE
feat: add arrow start offset option for improved arrow positioning

### DIFF
--- a/docs/stories/options/ArrowOptions.stories.tsx
+++ b/docs/stories/options/ArrowOptions.stories.tsx
@@ -25,6 +25,7 @@ export const ArrowOptions: Story = {
       activeArrowWidthMultiplier: 0.9,
       opacity: 0.65,
       activeOpacity: 0.5,
+      arrowStartOffset: 0,
     };
 
     // arrows
@@ -152,6 +153,24 @@ export const ArrowOptions: Story = {
                 setarrowOptions({
                   ...arrowOptions,
                   arrowWidthDenominator: Number(e.target.value),
+                })
+              }
+            />
+          </div>
+
+          {/* Start Offset */}
+          <div>
+            <label>Start Offset ({arrowOptions.arrowStartOffset}):</label>
+            <input
+              type="range"
+              min="0"
+              max="0.5"
+              step="0.02"
+              value={arrowOptions.arrowStartOffset}
+              onChange={(e) =>
+                setarrowOptions({
+                  ...arrowOptions,
+                  arrowStartOffset: Number(e.target.value),
                 })
               }
             />

--- a/src/Arrows.tsx
+++ b/src/Arrows.tsx
@@ -92,6 +92,10 @@ export function Arrows() {
         // This gives us the length of the arrow if it went from center to center
         const r = Math.hypot(dy, dx);
 
+        // Offset the start point from center to the edge of the square
+        // so the arrow begins at the square boundary rather than the piece center
+        const halfSquare = squareWidth * arrowOptions.arrowStartOffset;
+
         let pathD: string;
 
         // Is Knight move
@@ -99,16 +103,22 @@ export function Arrows() {
           // The mid point is only used in Knight move drawing
           // and here we prioritise drawing along the long edge
           // by defining the midpoint depending on which is bigger X or Y
-          const mid =
-            Math.abs(dx) < Math.abs(dy)
-              ? {
-                  x: from.x,
-                  y: to.y,
-                }
-              : {
-                  x: to.x,
-                  y: from.y,
-                };
+          const isVerticalFirst = Math.abs(dx) < Math.abs(dy);
+
+          // Offset start point toward the first leg direction
+          const start = isVerticalFirst
+            ? { x: from.x, y: from.y + Math.sign(dy) * halfSquare }
+            : { x: from.x + Math.sign(dx) * halfSquare, y: from.y };
+
+          const mid = isVerticalFirst
+            ? {
+                x: from.x,
+                y: to.y,
+              }
+            : {
+                x: to.x,
+                y: from.y,
+              };
 
           // Calculate the difference in x and y coordinates between mid and end points
           const dxEnd = to.x - mid.x;
@@ -121,31 +131,27 @@ export function Arrows() {
           // We subtract ARROW_LENGTH_REDUCER from the end line distance to make the arrow
           // stop before reaching the center of the target square
           const end = {
-            // Calculate new end x coordinate by:
-            // 1. Taking the mid->end x direction (dxEnd)
-            // 2. Scaling it by (rEnd - ARROW_LENGTH_REDUCER) / rEnd to shorten it
-            // 3. Adding to the mid x coordinate
             x: mid.x + (dxEnd * (rEnd - ARROW_LENGTH_REDUCER)) / rEnd,
-            // Same calculation for y coordinate
             y: mid.y + (dyEnd * (rEnd - ARROW_LENGTH_REDUCER)) / rEnd,
           };
 
-          pathD = `M${from.x},${from.y} L${mid.x},${mid.y} L${end.x},${end.y}`;
+          pathD = `M${start.x},${start.y} L${mid.x},${mid.y} L${end.x},${end.y}`;
         } else {
+          // Offset start point toward the target by half a square width
+          const start = {
+            x: from.x + (dx * halfSquare) / r,
+            y: from.y + (dy * halfSquare) / r,
+          };
+
           // Calculate the new end point for the arrow
           // We subtract ARROW_LENGTH_REDUCER from the total distance to make the arrow
           // stop before reaching the center of the target square
           const end = {
-            // Calculate new end x coordinate by:
-            // 1. Taking the original x direction (dx)
-            // 2. Scaling it by (r - ARROW_LENGTH_REDUCER) / r to shorten it
-            // 3. Adding to the starting x coordinate
             x: from.x + (dx * (r - ARROW_LENGTH_REDUCER)) / r,
-            // Same calculation for y coordinate
             y: from.y + (dy * (r - ARROW_LENGTH_REDUCER)) / r,
           };
 
-          pathD = `M${from.x},${from.y} L${end.x},${end.y}`;
+          pathD = `M${start.x},${start.y} L${end.x},${end.y}`;
         }
 
         return (

--- a/src/Arrows.tsx
+++ b/src/Arrows.tsx
@@ -120,8 +120,14 @@ export function Arrows() {
 
           // Shorten the final leg so the arrow stops before the target center
           const end = {
-            x: corner.x + (dxFinalLeg * (finalLegLength - ARROW_LENGTH_REDUCER)) / finalLegLength,
-            y: corner.y + (dyFinalLeg * (finalLegLength - ARROW_LENGTH_REDUCER)) / finalLegLength,
+            x:
+              corner.x +
+              (dxFinalLeg * (finalLegLength - ARROW_LENGTH_REDUCER)) /
+                finalLegLength,
+            y:
+              corner.y +
+              (dyFinalLeg * (finalLegLength - ARROW_LENGTH_REDUCER)) /
+                finalLegLength,
           };
 
           pathD = `M${start.x},${start.y} L${corner.x},${corner.y} L${end.x},${end.y}`;

--- a/src/Arrows.tsx
+++ b/src/Arrows.tsx
@@ -92,60 +92,47 @@ export function Arrows() {
         // This gives us the length of the arrow if it went from center to center
         const r = Math.hypot(dy, dx);
 
-        // Offset the start point from center to the edge of the square
-        // so the arrow begins at the square boundary rather than the piece center
-        const halfSquare = squareWidth * arrowOptions.arrowStartOffset;
+        // Distance to offset the arrow start from the square center
+        const startOffset = squareWidth * arrowOptions.arrowStartOffset;
 
         let pathD: string;
 
-        // Is Knight move
+        // Knight move - draw an L-shaped arrow
         if (r === Math.hypot(1, 2) * squareWidth) {
-          // The mid point is only used in Knight move drawing
-          // and here we prioritise drawing along the long edge
-          // by defining the midpoint depending on which is bigger X or Y
+          // Determine which direction to draw the long leg first
+          // We prioritize the longer axis for visual clarity
           const isVerticalFirst = Math.abs(dx) < Math.abs(dy);
 
-          // Offset start point toward the first leg direction
+          // Offset start point in the direction of the first leg
           const start = isVerticalFirst
-            ? { x: from.x, y: from.y + Math.sign(dy) * halfSquare }
-            : { x: from.x + Math.sign(dx) * halfSquare, y: from.y };
+            ? { x: from.x, y: from.y + Math.sign(dy) * startOffset }
+            : { x: from.x + Math.sign(dx) * startOffset, y: from.y };
 
-          const mid = isVerticalFirst
-            ? {
-                x: from.x,
-                y: to.y,
-              }
-            : {
-                x: to.x,
-                y: from.y,
-              };
+          // Corner where the L-shape turns
+          const corner = isVerticalFirst
+            ? { x: from.x, y: to.y }
+            : { x: to.x, y: from.y };
 
-          // Calculate the difference in x and y coordinates between mid and end points
-          const dxEnd = to.x - mid.x;
-          const dyEnd = to.y - mid.y;
+          // Calculate the final leg from corner to target
+          const dxFinalLeg = to.x - corner.x;
+          const dyFinalLeg = to.y - corner.y;
+          const finalLegLength = squareWidth; // Always one square for knight moves
 
-          // End arrow distance is always one squareWidth for Knight moves
-          const rEnd = squareWidth;
-
-          // Calculate the new end point for the arrow
-          // We subtract ARROW_LENGTH_REDUCER from the end line distance to make the arrow
-          // stop before reaching the center of the target square
+          // Shorten the final leg so the arrow stops before the target center
           const end = {
-            x: mid.x + (dxEnd * (rEnd - ARROW_LENGTH_REDUCER)) / rEnd,
-            y: mid.y + (dyEnd * (rEnd - ARROW_LENGTH_REDUCER)) / rEnd,
+            x: corner.x + (dxFinalLeg * (finalLegLength - ARROW_LENGTH_REDUCER)) / finalLegLength,
+            y: corner.y + (dyFinalLeg * (finalLegLength - ARROW_LENGTH_REDUCER)) / finalLegLength,
           };
 
-          pathD = `M${start.x},${start.y} L${mid.x},${mid.y} L${end.x},${end.y}`;
+          pathD = `M${start.x},${start.y} L${corner.x},${corner.y} L${end.x},${end.y}`;
         } else {
-          // Offset start point toward the target by half a square width
+          // Straight arrow - offset start point toward the target
           const start = {
-            x: from.x + (dx * halfSquare) / r,
-            y: from.y + (dy * halfSquare) / r,
+            x: from.x + (dx * startOffset) / r,
+            y: from.y + (dy * startOffset) / r,
           };
 
-          // Calculate the new end point for the arrow
-          // We subtract ARROW_LENGTH_REDUCER from the total distance to make the arrow
-          // stop before reaching the center of the target square
+          // Shorten the arrow so it stops before the target center
           const end = {
             x: from.x + (dx * (r - ARROW_LENGTH_REDUCER)) / r,
             y: from.y + (dy * (r - ARROW_LENGTH_REDUCER)) / r,

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -73,4 +73,5 @@ export const defaultArrowOptions = {
   activeArrowWidthMultiplier: 0.9, // the multiplier for the arrow width when it is being drawn
   opacity: 0.65, // opacity of arrow when not being drawn
   activeOpacity: 0.5, // opacity of arrow when it is being drawn
+  arrowStartOffset: 0, // how far from the center of the start square the arrow begins, as a fraction of square width (0 = center, 0.5 = edge). Values between 0.3-0.4 give a chess.com-like look where the arrow starts near the base of the piece. Values above 0.5 will start outside the square.
 };


### PR DESCRIPTION

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Adds a new arrowStartOffset property to arrowOptions that controls how far from the center of the starting square an arrow begins, as a fraction of the square width. This allows developers to offset arrow origins toward the edge of the square for a cleaner look (similar to chess.com), where arrows emerge from the base of a piece rather than its center.

  - 0 = arrow starts from the center of the square (default, preserves existing behavior)
  - 0.3–0.4 = arrow starts near the edge of the square, giving a chess.com-like appearance
  - 0.5 = arrow starts at the square boundary
  
Based on this [issue #222](https://github.com/Clariity/react-chessboard/issues/222)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Verified visually in Storybook ArrowOptions story with the new Start Offset slider across straight, diagonal, and knight move arrows
- [x] Confirmed default value of 0 preserves existing arrow behavior
- [x] pnpm test:static passes (tsc, eslint, prettier)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if appropriate):
Before:
<img width="514" height="809" alt="image" src="https://github.com/user-attachments/assets/9daf57fa-6c47-4f9f-b15c-46b56d6cb412" />

After:
<img width="515" height="803" alt="image" src="https://github.com/user-attachments/assets/45db7007-dd73-47b2-a0ea-025d6d25f625" />



## Additional context

Add any other context about the pull request here.
