### PR TITLE
feat: export type alias for square renderer

### DIFF
--- a/src/ChessboardProvider.tsx
+++ b/src/ChessboardProvider.tsx
@@ -35,6 +35,7 @@ import {
   PieceRenderObject,
   PositionDataType,
   SquareHandlerArgs,
+  SquareRenderer,
 } from './types';
 import { defaultPieces } from './pieces';
 import {
@@ -201,11 +202,7 @@ export type ChessboardOptions = {
     e: React.MouseEvent,
   ) => void;
   onSquareRightClick?: ({ piece, square }: SquareHandlerArgs) => void;
-  squareRenderer?: ({
-    piece,
-    square,
-    children,
-  }: SquareHandlerArgs & { children?: React.ReactNode }) => React.JSX.Element;
+  squareRenderer?: SquareRenderer;
 };
 
 export function ChessboardProvider({

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,12 @@ export type PieceDropHandlerArgs = {
   targetSquare: string | null;
 };
 
+export type SquareRenderer = ({
+  piece,
+  square,
+  children,
+}: SquareHandlerArgs & { children?: React.ReactNode }) => React.JSX.Element;
+
 export type PieceRenderObject = Record<
   string,
   (props?: {


### PR DESCRIPTION
this is a pretty small change but I often find that I want to put my square renderer function in some variable, separated from the rest of the chessboard options object. to do that i currently need to type it as `ChessboardOptions["squareRenderer"]` which is a bit verbose so I just exported a convenience type, `SquareRenderer`, for the square renderer callback.

thanks :)