### PR TITLE
add liveDrawArrow and knightArrow options to arrowOptions 

### DIFF
--- a/docs/D_OptionsApi.mdx
+++ b/docs/D_OptionsApi.mdx
@@ -256,6 +256,10 @@ When drawing an arrow, you can hold down modifier keys to change the arrow color
 - `opacity`: Controls the opacity of arrows when not being drawn
 - `activeOpacity`: Controls the opacity of arrows when they are being drawn
 
+#### Arrow behavior
+
+- `liveDrawArrow`: Controls whether the arrow is drawn live while dragging (`true`) or drawn after the final target is set (`false`)
+
 **Default value:**
 
 ```tsx
@@ -274,6 +278,7 @@ When drawing an arrow, you can hold down modifier keys to change the arrow color
   opacity: 0.65,
   activeOpacity: 0.5,
   arrowStartOffset: 0,
+  liveDrawArrow: true,
 }
 ```
 
@@ -288,13 +293,14 @@ When drawing an arrow, you can hold down modifier keys to change the arrow color
     alt?: string;
     meta?: string;
   },
-  arrowLengthReducerDenominator: number,
-  sameTargetArrowLengthReducerDenominator: number,
-  arrowWidthDenominator: number,
-  activeArrowWidthMultiplier: number,
-  opacity: number,
-  activeOpacity: number
-  arrowStartOffset: number,
+  arrowLengthReducerDenominator?: number,
+  sameTargetArrowLengthReducerDenominator?: number,
+  arrowWidthDenominator?: number,
+  activeArrowWidthMultiplier?: number,
+  opacity?: number,
+  activeOpacity?: number,
+  arrowStartOffset?: number,
+  liveDrawArrow?: boolean,
 }
 ```
 

--- a/docs/D_OptionsApi.mdx
+++ b/docs/D_OptionsApi.mdx
@@ -259,6 +259,7 @@ When drawing an arrow, you can hold down modifier keys to change the arrow color
 #### Arrow behavior
 
 - `liveDrawArrow`: Controls whether the arrow is drawn live while dragging (`true`) or drawn after the final target is set (`false`)
+- `knightArrow`: Controls whether knight moves are rendered as L-shaped knight arrows (`true`) or direct arrows (`false`)
 
 **Default value:**
 
@@ -279,6 +280,7 @@ When drawing an arrow, you can hold down modifier keys to change the arrow color
   activeOpacity: 0.5,
   arrowStartOffset: 0,
   liveDrawArrow: true,
+  knightArrow: true,
 }
 ```
 
@@ -301,6 +303,7 @@ When drawing an arrow, you can hold down modifier keys to change the arrow color
   activeOpacity?: number,
   arrowStartOffset?: number,
   liveDrawArrow?: boolean,
+  knightArrow?: boolean,
 }
 ```
 

--- a/docs/stories/options/ArrowOptions.stories.tsx
+++ b/docs/stories/options/ArrowOptions.stories.tsx
@@ -33,6 +33,7 @@ export const ArrowOptions: Story = {
       opacity: 0.65,
       activeOpacity: 0.5,
       arrowStartOffset: 0,
+      liveDrawArrow: true,
     };
 
     // arrows
@@ -263,6 +264,25 @@ export const ArrowOptions: Story = {
                 })
               }
             />
+          </div>
+
+          {/* Toggles */}
+          <div>
+            <label
+              style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}
+            >
+              <input
+                type="checkbox"
+                checked={arrowOptions.liveDrawArrow}
+                onChange={(e) =>
+                  setarrowOptions({
+                    ...arrowOptions,
+                    liveDrawArrow: e.target.checked,
+                  })
+                }
+              />
+              Live Draw Arrow
+            </label>
           </div>
         </div>
 

--- a/docs/stories/options/ArrowOptions.stories.tsx
+++ b/docs/stories/options/ArrowOptions.stories.tsx
@@ -34,6 +34,7 @@ export const ArrowOptions: Story = {
       activeOpacity: 0.5,
       arrowStartOffset: 0,
       liveDrawArrow: true,
+      knightArrow: true,
     };
 
     // arrows
@@ -282,6 +283,23 @@ export const ArrowOptions: Story = {
                 }
               />
               Live Draw Arrow
+            </label>
+          </div>
+          <div>
+            <label
+              style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}
+            >
+              <input
+                type="checkbox"
+                checked={arrowOptions.knightArrow}
+                onChange={(e) =>
+                  setarrowOptions({
+                    ...arrowOptions,
+                    knightArrow: e.target.checked,
+                  })
+                }
+              />
+              Knight Arrow
             </label>
           </div>
         </div>

--- a/src/Arrows.tsx
+++ b/src/Arrows.tsx
@@ -20,6 +20,7 @@ export function Arrows() {
   const viewBoxHeight = viewBoxWidth * (chessboardRows / chessboardColumns);
 
   const liveDrawArrow = arrowOptions.liveDrawArrow ?? true;
+  const knightArrow = arrowOptions.knightArrow ?? true;
 
   const currentlyDrawingArrow =
     liveDrawArrow &&
@@ -101,7 +102,10 @@ export function Arrows() {
         let pathD: string;
 
         // Knight move - draw an L-shaped arrow
-        if (r === Math.hypot(1, 2) * squareWidth) {
+        const isKnightMove =
+          Math.abs(r - Math.hypot(1, 2) * squareWidth) < 0.001 ||
+          r === Math.hypot(1, 2) * squareWidth;
+        if (knightArrow && isKnightMove) {
           // Determine which direction to draw the long leg first
           // We prioritize the longer axis for visual clarity
           const isVerticalFirst = Math.abs(dx) < Math.abs(dy);

--- a/src/Arrows.tsx
+++ b/src/Arrows.tsx
@@ -19,7 +19,10 @@ export function Arrows() {
   const viewBoxWidth = 2048;
   const viewBoxHeight = viewBoxWidth * (chessboardRows / chessboardColumns);
 
+  const liveDrawArrow = arrowOptions.liveDrawArrow ?? true;
+
   const currentlyDrawingArrow =
+    liveDrawArrow &&
     newArrowStartSquare &&
     newArrowOverSquare &&
     newArrowStartSquare !== newArrowOverSquare.square

--- a/src/ChessboardProvider.tsx
+++ b/src/ChessboardProvider.tsx
@@ -574,7 +574,7 @@ export function ChessboardProvider({
         altKey?: boolean;
         metaKey?: boolean;
       },
-      ) => {
+    ) => {
       // TODO: remove support for legacy arrow color props in future breaking version
       let color = arrowOptions.color;
       if (arrowOptions.colors) {

--- a/src/ChessboardProvider.tsx
+++ b/src/ChessboardProvider.tsx
@@ -96,7 +96,7 @@ type ContextType = {
 
   allowDrawingArrows: Defined<ChessboardOptions['allowDrawingArrows']>;
   arrows: Defined<ChessboardOptions['arrows']>;
-  arrowOptions: Defined<ChessboardOptions['arrowOptions']>;
+  arrowOptions: typeof defaultArrowOptions;
 
   canDragPiece: ChessboardOptions['canDragPiece'];
   onMouseOutSquare: ChessboardOptions['onMouseOutSquare'];
@@ -186,7 +186,7 @@ export type ChessboardOptions = {
   // arrows
   allowDrawingArrows?: boolean;
   arrows?: Arrow[];
-  arrowOptions?: typeof defaultArrowOptions;
+  arrowOptions?: Partial<typeof defaultArrowOptions>;
   clearArrowsOnClick?: boolean;
   clearArrowsOnPositionChange?: boolean;
 
@@ -262,7 +262,7 @@ export function ChessboardProvider({
     // arrows
     allowDrawingArrows = true,
     arrows = [],
-    arrowOptions = defaultArrowOptions,
+    arrowOptions: userArrowOptions = defaultArrowOptions,
     clearArrowsOnClick = true,
     clearArrowsOnPositionChange = true,
 
@@ -280,6 +280,11 @@ export function ChessboardProvider({
     onSquareRightClick,
     squareRenderer,
   } = options || {};
+
+  const arrowOptions = useMemo(
+    () => ({ ...defaultArrowOptions, ...userArrowOptions }),
+    [userArrowOptions],
+  );
 
   // the piece currently being dragged
   const [draggingPiece, setDraggingPiece] =

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -86,4 +86,5 @@ export const defaultArrowOptions = {
   activeOpacity: 0.5, // opacity of arrow when it is being drawn
   arrowStartOffset: 0, // how far from the center of the start square the arrow begins, as a fraction of square width (0 = center, 0.5 = edge). Values between 0.3-0.4 give a chess.com-like look where the arrow starts near the base of the piece. Values above 0.5 will start outside the square.
   liveDrawArrow: true, // controls whether the arrow is drawn live while dragging or after final target set
+  knightArrow: true, // controls whether knight moves are rendered as L-shaped knight arrows or direct arrows
 };

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -85,4 +85,5 @@ export const defaultArrowOptions = {
   opacity: 0.65, // opacity of arrow when not being drawn
   activeOpacity: 0.5, // opacity of arrow when it is being drawn
   arrowStartOffset: 0, // how far from the center of the start square the arrow begins, as a fraction of square width (0 = center, 0.5 = edge). Values between 0.3-0.4 give a chess.com-like look where the arrow starts near the base of the piece. Values above 0.5 will start outside the square.
+  liveDrawArrow: true, // controls whether the arrow is drawn live while dragging or after final target set
 };


### PR DESCRIPTION
## Description

This PR adds two new configuration options to arrowOptions inside ChessboardOptions to provide developers with finer control over arrow drawing behavior and rendering style:                 

1. `liveDrawArrow` `(boolean, default: true)`:                                                     
Controls whether arrow drawing renders a live preview while right-click dragging over squares (true), or delays drawing until the final target square is set upon right-mouse release (false).

2. `knightArrow` `(boolean, default: true)`:                                                 
Controls whether knight moves are rendered as traditional L-shaped arrows (true), or as direct straight arrows connecting start and end squares (false).                                      


Additionally, `ChessboardOptions['arrowOptions']` was updated to `Partial<typeof defaultArrowOptions>` so consumers can supply partial `arrowOptions` objects (e.g. `arrowOptions={{ liveDrawArrow: false }}`) without TypeScript requiring all default properties.                  
                                                                                                 
Fixes # N/A                                                                                    
                                                                                                 
## Type of change                                                                              
                                                                                                 
[✓] New feature (non-breaking change which adds functionality)                                 
[✓] Documentation update                                                                       
                                                                                                 
## How Has This Been Tested?                                                                   
                                                                                                 
[✓] Static Verification: Ran pnpm run test:static (tsc, eslint, and prettier --check) to ensure 0 TypeScript errors, clean linting, and proper formatting.                                     
[✓] Storybook Integration: Updated `ArrowOptions.stories.tsx` with interactive toggle controls for liveDrawArrow and knightArrow to test toggling options dynamically.                        
                                                                                                 
## Checklist:                                                                                  
                                                                                                 
[✓] My code follows the style guidelines of this project                                       
[✓] I have performed a self-review of my own code                                              
[✓] I have commented my code, particularly in hard-to-understand areas                         
[✓] I have made corresponding changes to the documentation                                     
[✓] My changes generate no new warnings                                                        
[✓] New and existing unit tests pass locally with my changes                                   
[✓] Any dependent changes have been merged and published in downstream modules                 
                                                                                                 
## Screenshots (if appropriate):                                                               
                                                                                                 
N/A                                                                                            
                                                                                                 
## Additional context                                                                          
                                                                                                 
### Default Behavior Preserved                                                                 
                                                                                                 
Both options default to true, maintaining 100% backward compatibility with existing chessboard implementations.                                                                               
