### PR TITLE
On drag cancel prop

### DIFF
--- a/docs/D_OptionsApi.mdx
+++ b/docs/D_OptionsApi.mdx
@@ -31,6 +31,7 @@ import * as OnMouseOutSquareStories from './stories/options/OnMouseOutSquare.sto
 import * as OnMouseOverSquareStories from './stories/options/OnMouseOverSquare.stories';
 import * as OnPieceClickStories from './stories/options/OnPieceClick.stories';
 import * as OnPieceDragStories from './stories/options/OnPieceDrag.stories';
+import * as OnPieceDragCancelStories from './stories/options/OnPieceDragCancel.stories';
 import * as OnPieceDropStories from './stories/options/OnPieceDrop.stories';
 import * as OnSquareClickStories from './stories/options/OnSquareClick.stories';
 import * as OnSquareMouseDownStories from './stories/options/OnSquareMouseDown.stories';
@@ -86,6 +87,7 @@ The code for these examples can be viewed by clicking the "Show code" button in 
 | [onMouseOverSquare](#optionsonmouseoversquare)                     | Handler for mouse entering a square                                 |
 | [onPieceClick](#optionsonpiececlick)                               | Handler for clicking a piece                                        |
 | [onPieceDrag](#optionsonpiecedrag)                                 | Handler for starting to drag a piece                                |
+| [onPieceDragCancel](#optionsonpiecedragcancel)                     | Handler for when a piece drag is cancelled                          |
 | [onPieceDrop](#optionsonpiecedrop)                                 | Handler for dropping a piece                                        |
 | [onSquareClick](#optionsonsquareclick)                             | Handler for clicking a square                                       |
 | [onSquareMouseDown](#optionsonsquaremousedown)                     | Handler for mouse button down on a square                           |
@@ -672,6 +674,22 @@ Callback function triggered when a piece drag operation starts.
 **Standard use case:** Implementing custom drag and drop behavior or validation.
 
 <Canvas of={OnPieceDragStories.OnPieceDrag} />
+
+### `options.onPieceDragCancel`
+
+Callback function triggered when a piece drag operation is cancelled. A drag is cancelled by pressing Escape or right-clicking, but not by dropping a piece outside the board.
+
+**Default value:** `undefined`
+
+**TypeScript type:**
+
+```typescript
+() => void;
+```
+
+**Standard use case:** Resetting UI state when the user cancels a drag without making a move.
+
+<Canvas of={OnPieceDragCancelStories.OnPieceDragCancel} />
 
 ### `options.onPieceDrop`
 

--- a/docs/stories/options/OnPieceDragCancel.stories.tsx
+++ b/docs/stories/options/OnPieceDragCancel.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import defaultMeta from '../basic-examples/Default.stories.js';
+import { Chessboard } from '../../../src/index.js';
+
+const meta: Meta<typeof Chessboard> = {
+  ...defaultMeta,
+  title: 'stories/Options/OnPieceDragCancel',
+} satisfies Meta<typeof Chessboard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const OnPieceDragCancel: Story = {
+  render: () => {
+    const [cancelCount, setCancelCount] = useState<number>(0);
+
+    // handle piece drag cancel
+    const onPieceDragCancel = () => {
+      setCancelCount((prev) => prev + 1);
+    };
+
+    // chessboard options
+    const chessboardOptions = {
+      onPieceDragCancel,
+      id: 'on-piece-drag-cancel',
+    };
+
+    // render
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1rem',
+          alignItems: 'center',
+        }}
+      >
+        <div>Drag cancelled: {cancelCount} time{cancelCount !== 1 ? 's' : ''}</div>
+
+        <Chessboard options={chessboardOptions} />
+
+        <p style={{ fontSize: '0.8rem', color: '#666' }}>
+          Start dragging a piece and click right click or press Escape to trigger a drag cancel 
+        </p>
+      </div>
+    );
+  },
+};

--- a/docs/stories/options/OnPieceDragCancel.stories.tsx
+++ b/docs/stories/options/OnPieceDragCancel.stories.tsx
@@ -37,12 +37,15 @@ export const OnPieceDragCancel: Story = {
           alignItems: 'center',
         }}
       >
-        <div>Drag cancelled: {cancelCount} time{cancelCount !== 1 ? 's' : ''}</div>
+        <div>
+          Drag cancelled: {cancelCount} time{cancelCount !== 1 ? 's' : ''}
+        </div>
 
         <Chessboard options={chessboardOptions} />
 
         <p style={{ fontSize: '0.8rem', color: '#666' }}>
-          Start dragging a piece and click right click or press Escape to trigger a drag cancel 
+          Start dragging a piece and click right click or press Escape to
+          trigger a drag cancel
         </p>
       </div>
     );

--- a/src/ChessboardProvider.tsx
+++ b/src/ChessboardProvider.tsx
@@ -187,6 +187,7 @@ export type ChessboardOptions = {
   onMouseOverSquare?: ({ piece, square }: SquareHandlerArgs) => void;
   onPieceClick?: ({ isSparePiece, piece, square }: PieceHandlerArgs) => void;
   onPieceDrag?: ({ isSparePiece, piece, square }: PieceHandlerArgs) => void;
+  onPieceDragCancel?: () => void;
   onPieceDrop?: ({
     piece,
     sourceSquare,
@@ -263,6 +264,7 @@ export function ChessboardProvider({
     onMouseOverSquare,
     onPieceClick,
     onPieceDrag,
+    onPieceDragCancel,
     onPieceDrop,
     onSquareClick,
     onSquareMouseDown,
@@ -551,7 +553,8 @@ export function ChessboardProvider({
 
   const handleDragCancel = useCallback(() => {
     setDraggingPiece(null);
-  }, []);
+    onPieceDragCancel?.();
+  }, [onPieceDragCancel]);
 
   const handleDragEnd = useCallback(
     function handleDragEnd(event: DragEndEvent) {


### PR DESCRIPTION
 ## Description

   This PR adds `onPieceDragCancel` prop to be able to customize the UI cleanup when the user explicitly cancel a drag event by right clicking or pressing Escape.

   ## Type of change

   - [x] New feature (non-breaking change which adds functionality)
   - [x] Documentation update


   ## How Has This Been Tested?

   Please describe the tests that you ran to verifstructions so we can reproduce.

   - [x] Manual Storybook Testing: Spun up `pnpm storybook` and verified that right clicking or pressing Escape triggers the callback but drag and dropping a piece outside the board does not.
   - [x] Static Testing: Ran `pnpm test:static` locally to ensure no TypeScript compilation errors or Prettier formatting issues were introduced by the updated ChessboardOptions type definitions.

   ## Checklist:

   - [x] My code follows the style guidelines of this project
   - [x] I have performed a self-review of my own
   - [x] I have commented my code, particularly in
   - [x] I have made corresponding changes to the
   - [x] My changes generate no new warnings
   - [x] I have added tests that prove my fix is effective or that my feature works
   - [x] New and existing unit tests pass locally
   - [ ] Any dependent changes have been merged anmodules